### PR TITLE
Adds a deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,23 @@
+name: waykup.ch deploy
+
+on:
+  push:
+    branches: [ production ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+        
+    - name: Sync
+      env:
+        dest: 'eebulle@${{secrets.DEPLOY_ADDR}}:/var/www/waykup.ch/public_html/'
+      run: |
+        echo "${{secrets.DEPLOY_KEY}}" > deploy_key
+        chmod 600 ./deploy_key
+        rsync -chav --delete \
+          --exclude=".git" \
+          -e 'ssh -p ${{secrets.DEPLOY_PORT}} -i ./deploy_key -o StrictHostKeyChecking=no' \
+          ./ ${{env.dest}}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,5 +19,6 @@ jobs:
         chmod 600 ./deploy_key
         rsync -chav --delete \
           --exclude=".git" \
+          --exclude="README.md" \
           -e 'ssh -p ${{secrets.DEPLOY_PORT}} -i ./deploy_key -o StrictHostKeyChecking=no' \
           ./ ${{env.dest}}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+Waykup website: https://waykup.ch
+
+## Deploy
+
+Updating the production branch will trigger a deploy action that updates the
+production server. The production branch must only be used for that purpose. A
+standard deploy involves merging the master branch into the production branch:
+
+```bash
+# get the latest update from master locally
+git pull
+# merge master into production
+git push origin master:production
+```


### PR DESCRIPTION
This PR adds a Github action to automatically deploy the website when the production branch is updated.

@hausmanne from now on the old SPHA deployment **won't work anymore**. I let you accept and merge this PR. After that you will have to merge the master branch into the production branch in order to trigger a deployment:

```bash
# get the latest update from master locally
git pull
# merge master into production
git push origin master:production
```